### PR TITLE
Fix generic method call

### DIFF
--- a/src/Jokenizer.Net/ExtensionMethods.cs
+++ b/src/Jokenizer.Net/ExtensionMethods.cs
@@ -44,6 +44,8 @@ namespace Jokenizer.Net {
                 if (m.Name != name) return null;
 
                 if (m.IsGenericMethodDefinition) {
+                    if (m.GetGenericArguments().Count() != args.Length) return null;
+                    
                     m = m.MakeGenericMethod(args);
                 }
 

--- a/test/Jokenizer.Net.Tests/TokenizerTests.cs
+++ b/test/Jokenizer.Net.Tests/TokenizerTests.cs
@@ -236,5 +236,18 @@ namespace Jokenizer.Net.Tests {
             var le3 = re.Right as LiteralToken;
             Assert.Equal(3, le3.Value);
         }
+        
+        [Fact]
+        public void ShoulHandleNullArgument() {
+            var call = new CallToken(null);
+            var group = new GroupToken(null);
+            var lambda = new LambdaToken(null);
+            var obj = new ObjectToken(null);
+
+            Assert.NotNull(call.Args);
+            Assert.NotNull(group.Tokens);
+            Assert.NotNull(lambda.Parameters);
+            Assert.NotNull(obj.Members);
+        }
     }
 }


### PR DESCRIPTION
## Change list

* Fix inner method call
 
## Types of changes

What types of changes are you proposing/introducing?
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details
Jokenizer does not support generics, so it makes a guess when we call a method inside string expression. By improving method selection we can allow expressions like this;

"(o, l) => o.Id + l.Max(x => x.Id)"
